### PR TITLE
Ablity to Update Maps from Sources & Don't Check Material if in Creative

### DIFF
--- a/src/main/java/org/acornmc/drmap/command/CommandDrmap.java
+++ b/src/main/java/org/acornmc/drmap/command/CommandDrmap.java
@@ -53,6 +53,9 @@ public class CommandDrmap implements TabExecutor {
             if (sender.hasPermission("drmap.command.erase")) {
                 list.add("erase");
             }
+            if (sender.hasPermission("drmap.command.update")) {
+                list.add("update");
+            }
             return StringUtil.copyPartialMatches(args[0], list, new ArrayList<>());
         } else if (args.length >= 3 && sender.hasPermission("drmap.command.create") && args[0].equalsIgnoreCase("create")) {
             boolean includedWidth = false;
@@ -220,6 +223,14 @@ public class CommandDrmap implements TabExecutor {
                     meta.getPersistentDataContainer().set(keyPart, PersistentDataType.INTEGER_ARRAY, new int[]{0,0,0,0});
                     NamespacedKey keySource = new NamespacedKey(plugin, "drmap-source");
                     meta.getPersistentDataContainer().set(keySource, PersistentDataType.STRING, args[1]);
+                    NamespacedKey keyProportion = new NamespacedKey(plugin, "drmap-proportion");
+                    meta.getPersistentDataContainer().set(keyProportion, PersistentDataType.BYTE, (byte) 1);
+                    NamespacedKey keyIds = new NamespacedKey(plugin, "drmap-ids");
+                    meta.getPersistentDataContainer().set(keyIds, PersistentDataType.INTEGER_ARRAY, new int[]{mapView.getId()});
+                    if (finalBackground != null) {
+                        NamespacedKey keyBackground = new NamespacedKey(plugin, "drmap-background");
+                        meta.getPersistentDataContainer().set(keyBackground, PersistentDataType.INTEGER_ARRAY, new int[]{finalBackground.getRed(), finalBackground.getGreen(), finalBackground.getBlue(), finalBackground.getAlpha()});
+                    }
 
                     // Apply the meta changes
                     map.setItemMeta(meta);
@@ -255,6 +266,7 @@ public class CommandDrmap implements TabExecutor {
                 }
 
                 List<ItemStack> maps = new LinkedList<>();
+                List<Integer> ids = new LinkedList<>();
                 for (int j = 0; j < images[0].length; j++) {
                     for (int i = 0; i < images.length; i++) {
                         MapView mapView = Bukkit.createMap(Bukkit.getWorlds().get(0));
@@ -284,10 +296,25 @@ public class CommandDrmap implements TabExecutor {
                         meta.getPersistentDataContainer().set(keyPart, PersistentDataType.INTEGER_ARRAY, new int[]{i, j, images.length - 1, images[0].length - 1});
                         NamespacedKey keySource = new NamespacedKey(plugin, "drmap-source");
                         meta.getPersistentDataContainer().set(keySource, PersistentDataType.STRING, args[1]);
+                        NamespacedKey keyProportion = new NamespacedKey(plugin, "drmap-proportion");
+                        meta.getPersistentDataContainer().set(keyProportion, PersistentDataType.BYTE, (byte) 0);
+                        if (finalBackground != null) {
+                            NamespacedKey keyBackground = new NamespacedKey(plugin, "drmap-background");
+                            meta.getPersistentDataContainer().set(keyBackground, PersistentDataType.INTEGER_ARRAY, new int[]{finalBackground.getRed(), finalBackground.getGreen(), finalBackground.getBlue(), finalBackground.getAlpha()});
+                        }
+
                         map.setItemMeta(meta);
 
                         maps.add(map);
+                        ids.add(mapView.getId());
                     }
+                }
+                NamespacedKey keyIds = new NamespacedKey(plugin, "drmap-ids");
+                int[] idsArray = ids.stream().mapToInt(i -> i).toArray();
+                for (ItemStack map : maps) {
+                    ItemMeta meta = map.getItemMeta();
+                    meta.getPersistentDataContainer().set(keyIds, PersistentDataType.INTEGER_ARRAY, idsArray);
+                    map.setItemMeta(meta);
                 }
 
                 //Remove empty maps
@@ -314,6 +341,87 @@ public class CommandDrmap implements TabExecutor {
             return true;
         }
 
+        if (args[0].equalsIgnoreCase("update")) {
+            if (!sender.hasPermission("drmap.command.update")) {
+                Lang.send(sender, Lang.COMMAND_NO_PERMISSION);
+                return true;
+            }
+            if (!(sender instanceof Player)) {
+                Lang.send(sender, Lang.NOT_PLAYER);
+                return true;
+            }
+            Player player = (Player) sender;
+            ItemStack hand = player.getInventory().getItemInMainHand();
+            if (!Util.isDrMap(hand)) {
+                Lang.send(sender, Lang.NOT_DRMAP);
+                return true;
+            }
+            ItemMeta itemMeta = hand.getItemMeta();
+            if (!(itemMeta instanceof MapMeta)) {
+                Lang.send(sender, Lang.NOT_DRMAP);
+                return true;
+            }
+            PersistentDataContainer container = itemMeta.getPersistentDataContainer();
+
+            String source = PictureMeta.getSource(container, plugin);
+            int[] idsArray = PictureMeta.getIds(container, ((MapMeta) itemMeta).getMapView().getId(), plugin);
+            Color finalBackground = PictureMeta.getBackground(container, plugin);
+            boolean proportion = PictureMeta.isProportion(container, plugin);
+            int[] parts = PictureMeta.getParts(container, plugin);
+            int finalWidth = parts[2] + 1;
+            int finalHeight = parts[3] + 1;
+
+            if (proportion) {
+                CompletableFuture.supplyAsync(() -> PictureManager.INSTANCE.downloadProportionalImage(source, finalBackground)).whenCompleteAsync((Image image, Throwable exception) -> {
+                    if (image == null) {
+                        plugin.getLogger().warning("Could not download image: " + source);
+                        Lang.send(sender, Lang.ERROR_DOWNLOADING);
+                        return;
+                    }
+
+                    MapView mapView = Bukkit.getMap(idsArray[0]);
+
+                    if (!PictureManager.INSTANCE.saveImage(image, mapView.getId())) {
+                        plugin.getLogger().warning("Could not save image to disk: " + source + " -> " + mapView.getId() + ".png");
+                        Lang.send(sender, Lang.ERROR_DOWNLOADING);
+                        return;
+                    }
+
+                    PictureManager.INSTANCE.getPicture(mapView).updateWithImage(image);
+
+                    Lang.send(sender, Lang.IMAGE_UPDATED);
+                }, plugin.getMainThreadExecutor());
+                return true;
+            }
+
+            // If stretching the map
+            CompletableFuture.supplyAsync(() -> PictureManager.INSTANCE.downloadStretchedImage(source, finalWidth, finalHeight, finalBackground)).whenCompleteAsync((Image[][] images, Throwable exception) -> {
+                if (images == null) {
+                    plugin.getLogger().severe("Could not download image: " + source);
+                    Lang.send(sender, Lang.ERROR_DOWNLOADING);
+                    return;
+                }
+
+                int c = 0;
+                for (int j = 0; j < images[0].length; j++) {
+                    for (int i = 0; i < images.length; i++) {
+                        MapView mapView = Bukkit.getMap(idsArray[c]);
+                        if (!PictureManager.INSTANCE.saveImage(images[i][j], mapView.getId())) {
+                            plugin.getLogger().warning("Could not save image to disk: " + source + " -> " + mapView.getId() + ".png");
+                            Lang.send(sender, Lang.ERROR_DOWNLOADING);
+                            return;
+                        }
+
+                        PictureManager.INSTANCE.getPicture(mapView).updateWithImage(images[i][j]);
+                        c++;
+                    }
+                }
+
+                Lang.send(sender, Lang.IMAGE_UPDATED);
+            }, plugin.getMainThreadExecutor());
+            return true;
+        }
+
         if (args[0].equalsIgnoreCase("erase")) {
             if (!sender.hasPermission("drmap.command.erase")) {
                 Lang.send(sender, Lang.COMMAND_NO_PERMISSION);
@@ -334,6 +442,7 @@ public class CommandDrmap implements TabExecutor {
             player.getInventory().setItemInMainHand(blankMap);
             return true;
         }
+
         if (args[0].equalsIgnoreCase("info") || args[0].equalsIgnoreCase("author")) {
             if (!sender.hasPermission("drmap.command.info")) {
                 Lang.send(sender, Lang.COMMAND_NO_PERMISSION);

--- a/src/main/java/org/acornmc/drmap/command/CommandDrmap.java
+++ b/src/main/java/org/acornmc/drmap/command/CommandDrmap.java
@@ -8,6 +8,7 @@ import org.acornmc.drmap.picture.Picture;
 import org.acornmc.drmap.picture.PictureManager;
 import org.acornmc.drmap.picture.PictureMeta;
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.command.Command;
@@ -115,7 +116,7 @@ public class CommandDrmap implements TabExecutor {
 
             // Check if they have a map
             Player player = (Player) sender;
-            if (!player.getInventory().contains(Material.MAP)) {
+            if (!playerWithCheats(player) && !player.getInventory().contains(Material.MAP)) {
                 Lang.send(sender, Lang.MUST_HAVE_MAP);
                 return true;
             }
@@ -171,7 +172,7 @@ public class CommandDrmap implements TabExecutor {
             // Check that they have enough
             // We will check again after the image is downloaded,
             // but I don't want to download images if they don't even have enough maps
-            if (!(playerHas(player, Material.MAP, requiredAmount))) {
+            if (!playerWithCheats(player) && !(playerHas(player, Material.MAP, requiredAmount))) {
                 Lang.send(sender, Lang.NOT_ENOUGH_MAPS.replace("{required}", String.valueOf(requiredAmount)));
                 return true;
             }
@@ -223,12 +224,14 @@ public class CommandDrmap implements TabExecutor {
                     // Apply the meta changes
                     map.setItemMeta(meta);
 
-                    //Remove maps
-                    if (playerHas(player, Material.MAP, finalRequiredAmount)) {
-                        removeFromInventory(player, Material.MAP, finalRequiredAmount);
-                    } else {
-                        Lang.send(sender, Lang.NOT_ENOUGH_MAPS.replace("{required}", String.valueOf(finalRequiredAmount)));
-                        return;
+                    //Remove maps if not in creative
+                    if (!playerWithCheats(player)) {
+                        if (playerHas(player, Material.MAP, finalRequiredAmount)) {
+                            removeFromInventory(player, Material.MAP, finalRequiredAmount);
+                        } else {
+                            Lang.send(sender, Lang.NOT_ENOUGH_MAPS.replace("{required}", String.valueOf(finalRequiredAmount)));
+                            return;
+                        }
                     }
 
                     // Give map
@@ -288,11 +291,13 @@ public class CommandDrmap implements TabExecutor {
                 }
 
                 //Remove empty maps
-                if (playerHas(player, Material.MAP, finalRequiredAmount)) {
-                    removeFromInventory(player, Material.MAP, finalRequiredAmount);
-                } else {
-                    Lang.send(sender, Lang.NOT_ENOUGH_MAPS.replace("{required}", String.valueOf(finalRequiredAmount)));
-                    return;
+                if (!playerWithCheats(player)) {
+                    if (playerHas(player, Material.MAP, finalRequiredAmount)) {
+                        removeFromInventory(player, Material.MAP, finalRequiredAmount);
+                    } else {
+                        Lang.send(sender, Lang.NOT_ENOUGH_MAPS.replace("{required}", String.valueOf(finalRequiredAmount)));
+                        return;
+                    }
                 }
 
                 // Give filled maps
@@ -396,5 +401,10 @@ public class CommandDrmap implements TabExecutor {
             }
         }
         return false;
+    }
+    
+    public boolean playerWithCheats(Player player) {
+        GameMode gameMode = player.getGameMode();
+        return gameMode.equals(GameMode.CREATIVE) || gameMode.equals(GameMode.SPECTATOR);
     }
 }

--- a/src/main/java/org/acornmc/drmap/configuration/Lang.java
+++ b/src/main/java/org/acornmc/drmap/configuration/Lang.java
@@ -19,6 +19,7 @@ public class Lang {
     public static String COMMAND_NO_PERMISSION = "&4You do not have permission for that command.";
     public static String ERROR_DOWNLOADING = "&4Could not download image.";
     public static String IMAGE_CREATED = "&aDrMap created.";
+    public static String IMAGE_UPDATED = "&aDrMap updated.";
     public static String INFO_AUTHOR = "&aThis map was created by {author}.";
     public static String INFO_CREATION = "&aThis map was created on {creation}.";
     public static String INFO_PART = "&aThis map is part ({this-x} {this-y}) of ({max-x} {max-y}).";
@@ -33,6 +34,7 @@ public class Lang {
         ACTION_NO_PERMISSION = getString("action-no-permission", ACTION_NO_PERMISSION);
         ERROR_DOWNLOADING = getString("error", ERROR_DOWNLOADING);
         IMAGE_CREATED = getString("image-created", IMAGE_CREATED);
+        IMAGE_UPDATED = getString("image-updated", IMAGE_UPDATED);
         MUST_HAVE_MAP = getString("must-have-map", MUST_HAVE_MAP);
         NOT_PLAYER = getString("not-player", NOT_PLAYER);
         NOT_DRMAP = getString("not-drmap", NOT_DRMAP);

--- a/src/main/java/org/acornmc/drmap/picture/Picture.java
+++ b/src/main/java/org/acornmc/drmap/picture/Picture.java
@@ -9,7 +9,10 @@ public class Picture {
 
     public Picture(java.awt.Image image, MapView mapView) {
         this.mapView = mapView;
+        updateWithImage(image);
+    }
 
+    public void updateWithImage(java.awt.Image image) {
         for (MapRenderer render : mapView.getRenderers()) {
             mapView.removeRenderer(render);
         }

--- a/src/main/java/org/acornmc/drmap/picture/PictureManager.java
+++ b/src/main/java/org/acornmc/drmap/picture/PictureManager.java
@@ -14,20 +14,26 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class PictureManager {
     public static PictureManager INSTANCE = new PictureManager();
 
-    private Set<Picture> pictures = new HashSet<>();
+    private Map<MapView, Picture> pictures = new HashMap<>();
 
     public void addPicture(Picture picture) {
-        pictures.add(picture);
+        pictures.put(picture.getMapView(), picture);
+    }
+
+    public Picture getPicture(MapView mapView) {
+        return pictures.get(mapView);
     }
 
     public void sendAllMaps(Player player) {
-        pictures.forEach(picture -> player.sendMap(picture.getMapView()));
+        pictures.values().forEach(picture -> player.sendMap(picture.getMapView()));
     }
 
     public Image[][] downloadStretchedImage(String link, int width, int height, Color finalBackground) {

--- a/src/main/java/org/acornmc/drmap/picture/PictureMeta.java
+++ b/src/main/java/org/acornmc/drmap/picture/PictureMeta.java
@@ -13,10 +13,12 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
+import java.awt.Color;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.UUID;
+import java.util.stream.IntStream;
 
 public class PictureMeta {
 
@@ -96,6 +98,31 @@ public class PictureMeta {
     public static String getSource(PersistentDataContainer container, DrMap plugin) {
         NamespacedKey keySource = new NamespacedKey(plugin, "drmap-source");
         return container.get(keySource, PersistentDataType.STRING);
+    }
+
+    public static int[] getIds(PersistentDataContainer container, int mapId, DrMap plugin) {
+        NamespacedKey keyIds = new NamespacedKey(plugin, "drmap-ids");
+        int[] ids = container.get(keyIds, PersistentDataType.INTEGER_ARRAY);
+        if (ids != null) {
+            return ids;
+        }
+        int[] parts = getParts(container, plugin);
+        int width = parts[2] + 1;
+        int start = mapId - (parts[0] + parts[1] * width);
+        int end = start + (width * (parts[3] + 1));
+        return IntStream.range(start, end).toArray();
+    }
+
+    public static boolean isProportion(PersistentDataContainer container, DrMap plugin) {
+        NamespacedKey keyProportion = new NamespacedKey(plugin, "drmap-proportion");
+        Byte value = container.get(keyProportion, PersistentDataType.BYTE);
+        return value != null && value != 0;
+    }
+
+    public static Color getBackground(PersistentDataContainer container, DrMap plugin) {
+        NamespacedKey keyBackground = new NamespacedKey(plugin, "drmap-background");
+        int[] value = container.get(keyBackground, PersistentDataType.INTEGER_ARRAY);
+        return value == null ? null : new Color(value[0], value[1], value[2], value[3]);
     }
 
     public static boolean playerHasAllParts(PersistentDataContainer container, Player player, DrMap plugin) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -24,6 +24,11 @@ permissions:
     description: erase drmaps
     children:
       drmap.command: true
+  drmap.command.update:
+    default: op
+    description: update drmaps
+    children:
+      drmap.command: true
   drmap.place:
     default: op
     description: place drmaps in item frames


### PR DESCRIPTION
This PR adds the ability to update existing images from their original URL sources.
Also, creative players would have maps in their creative inventory so it doesn't make sense to check whether they have them or not.