### PR TITLE
Replace nbtapi with library that doesn't depend on nms nbt classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,10 +108,9 @@
 <!--            <scope>provided</scope>-->
 <!--        </dependency>-->
         <dependency>
-            <groupId>de.tr7zw</groupId>
-            <artifactId>item-nbt-api</artifactId>
-            <version>2.15.1-SNAPSHOT</version>
-            <scope>compile</scope>
+            <groupId>com.github.Querz</groupId>
+            <artifactId>NBT</artifactId>
+            <version>6.1</version>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.acornmc</groupId>
     <artifactId>DrMap</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     <packaging>jar</packaging>
 
     <name>DrMap</name>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.21.6-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 <!--        <dependency>-->
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.1-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.16.0</version>
+            <version>4.23.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,11 @@
                     <relocations>
                         <relocation>
                             <pattern>org.bstats</pattern>
-                            <shadedPattern>org.acornmc.shade.bstats</shadedPattern>
+                            <shadedPattern>org.acornmc.drmap.shade.bstats</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>de.tr7zw.changeme.nbtapi</pattern>
-                            <shadedPattern>org.acornmc.shade.nbtapi</shadedPattern>
+                            <pattern>net.querz</pattern>
+                            <shadedPattern>org.acornmc.drmap.shade.querz</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>


### PR DESCRIPTION
This pull replaces nbtapi with a library that doesn't rely on the servers internal nbt classes to read files.
This makes it version independent.
Library: https://github.com/Querz/NBT (MIT License)

Changes:
- Replace nbtapi
- Bump some depends
- Use temporary file for updates to idcounts so that the file isn't corrupted if we error while writing for any reason
- Clean up some logging