### PR TITLE
Fix compat with 26.1+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.acornmc</groupId>
     <artifactId>DrMap</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>DrMap</name>
@@ -38,10 +38,16 @@
                             <shadedPattern>org.acornmc.drmap.shade.bstats</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>net.querz</pattern>
-                            <shadedPattern>org.acornmc.drmap.shade.querz</shadedPattern>
+                            <pattern>net.kyori.adventure.nbt</pattern>
+                            <shadedPattern>org.acornmc.drmap.shade.kyori.nbt</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <!-- transitive of above nbt package -->
+                            <pattern>net.kyori.examination</pattern>
+                            <shadedPattern>org.acornmc.drmap.shade.kyori.examination</shadedPattern>
                         </relocation>
                     </relocations>
+                    <minimizeJar>true</minimizeJar>
                 </configuration>
                 <executions>
                     <execution>
@@ -93,19 +99,31 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.11-R0.1-SNAPSHOT</version>
+            <version>26.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>io.github.ensgijs</groupId>
-            <artifactId>ens-nbt</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-nbt</artifactId>
+            <version>4.26.1</version>
             <scope>compile</scope>
+            <exclusions>
+                <!-- junk not needed in the final jar -->
+                <!-- don't exclude the examination package as it is used by nbt for stuff like toString() -->
+                <exclusion>
+                    <groupId>org.intellij</groupId>
+                    <artifactId>lang</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>3.0.2</version>
+            <version>3.2.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/acornmc/drmap/picture/PictureManager.java
+++ b/src/main/java/org/acornmc/drmap/picture/PictureManager.java
@@ -1,9 +1,8 @@
 package org.acornmc.drmap.picture;
 
-import io.github.ensgijs.nbt.io.CompressionType;
-import io.github.ensgijs.nbt.io.BinaryNbtHelpers;
-import io.github.ensgijs.nbt.tag.CompoundTag;
-import io.github.ensgijs.nbt.tag.Tag;
+import net.kyori.adventure.nbt.BinaryTagIO;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.IntBinaryTag;
 import org.acornmc.drmap.DrMap;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -14,12 +13,15 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class PictureManager {
     public static PictureManager INSTANCE = new PictureManager();
@@ -94,40 +96,107 @@ public class PictureManager {
                 DrMap.getInstance().getLogger().log(Level.WARNING, "Failed to load image: " + file, e);
             }
         }
-        DrMap.getInstance().getLogger().info("Loaded " + count + " images from disk");
+
         bumpMapId(highestId);
+        DrMap.getInstance().getLogger().info("Loaded " + count + " images from disk");
     }
 
-    public static void bumpMapId(int highestDrMap) {
-        if (highestDrMap == 0) return;
-        World mainWorld = Bukkit.getWorlds().getFirst();
-        File worldFolder = mainWorld.getWorldFolder();
-        Path dataFolder = worldFolder.toPath().resolve("data");
-        Path idCounts = dataFolder.resolve("idcounts.dat");
-
-        // If the idcounts file doesn't exist, creating a map with the API should create it.
-        if (!Files.exists(idCounts)) {
-            Bukkit.createMap(mainWorld);
-        }
+    public static boolean bumpMapId(int highestId) {
+        if (highestId == 0)
+            return true;
 
         try {
-            // Step 1: Read the Gzip'd NBT data
-            Tag<?> tag = BinaryNbtHelpers.read(idCounts.toFile(), CompressionType.GZIP).getTag();
-            CompoundTag nbt = (CompoundTag) tag;
+            String bukkitVer = Bukkit.getBukkitVersion();
+            Matcher verMatch = Pattern.compile("^(?<major>\\d+)(?:\\.(?<minor>\\d+)(?:\\.(?<patch>\\d+))?)?")
+                    .matcher(bukkitVer);
+            if (!verMatch.find())
+                throw new RuntimeException("Failed to resolve minecraft version: " + bukkitVer);
+            int major = Integer.parseInt(verMatch.group("major"));
+            int minor = verMatch.group("minor") == null ? 0 : Integer.parseInt(verMatch.group("minor"));
+            int patch = verMatch.group("patch") == null ? 0 : Integer.parseInt(verMatch.group("patch"));
 
-            CompoundTag nbtData = nbt.get("data", CompoundTag.class);
-            if (nbtData == null) return;
-            int mapId = nbtData.getInt("map");
-            if (mapId < highestDrMap) {
-                nbtData.putInt("map", highestDrMap);
-                // write to tmp file to prevent corrupting the servers idcounts if we fail
-                Path idCountsTmp = idCounts.resolveSibling("idcounts.dat.drmap.tmp");
-                BinaryNbtHelpers.write(tag, idCountsTmp.toFile(), CompressionType.GZIP);
-                Files.move(idCountsTmp, idCounts, StandardCopyOption.REPLACE_EXISTING);
-                DrMap.getInstance().getLogger().info("Updated idcounts.dat from " + mapId + " to " + highestDrMap + ".");
+            if (major >= 26) {
+                return bumpMapIdModern(highestId);
+            } else {
+                return bumpMapIdLegacy(highestId);
             }
         } catch (Exception e) {
-            DrMap.getInstance().getLogger().log(Level.WARNING, "Failed to update idcounts.dat", e);
+            DrMap.getInstance().getLogger().log(Level.SEVERE, "Failed to bump map id: " + highestId, e);
+            return false;
         }
     }
+
+    private static boolean bumpMapIdModern(int highestId) throws Exception {
+        Class<?> mcServerClazz = Class.forName("net.minecraft.server.MinecraftServer");
+        Class<?> savedDataTypeClazz = Class.forName("net.minecraft.world.level.saveddata.SavedDataType");
+        Class<?> mapIndexClazz = Class.forName("net.minecraft.world.level.saveddata.maps.MapIndex");
+
+        // mapIndex = MinecraftServer.getServer().getDataStorage().computeIfAbsent(MapIndex.TYPE)
+        Object mcServer = mcServerClazz.getMethod("getServer").invoke(null);
+        Object savedDataStorage = mcServerClazz.getMethod("getDataStorage").invoke(mcServer);
+        Object mapIndexType = mapIndexClazz.getField("TYPE").get(null);
+        Object mapIndex = savedDataStorage.getClass().getMethod("computeIfAbsent", savedDataTypeClazz).invoke(savedDataStorage, mapIndexType);
+
+        // get the private lastMapId field of the returned MapIndex representing the current highest map id
+        Field f_mapIndex_lastMapId = mapIndexClazz.getDeclaredField("lastMapId");
+        f_mapIndex_lastMapId.setAccessible(true);
+
+        int last = f_mapIndex_lastMapId.getInt(mapIndex);
+        if (last >= highestId)
+            return true;
+
+        // set to value-1 as the following call bumps by 1 and marks it for saving
+        // even if getNextMapId fails, the above branch ensures that the set value is at least the previous one.
+        f_mapIndex_lastMapId.set(mapIndex, highestId - 1);
+        Object mapId = mapIndexClazz.getMethod("getNextMapId").invoke(mapIndex);
+
+        // rather than use lastMapId, check the returned MapId for redundancy
+        int current = (int) mapId.getClass().getMethod("id").invoke(mapId);
+        if (current != highestId)
+            throw new IllegalStateException("Failed to bump map id. expected=" + highestId + " got=" + current + " previous=" + last);
+        DrMap.getInstance().getLogger().info("Updated current map ID from " + last + " to " + current + ".");
+        return true;
+    }
+
+    private static boolean bumpMapIdLegacy(int highestId) throws Exception {
+        World mainWorld = Bukkit.getWorlds().getFirst();
+        Path mapIdsFile = mainWorld.getWorldFolder().toPath().resolve("data").resolve("idcounts.dat");
+
+        // If the map ids file doesn't exist, creating a map with the API should hopefully create it.
+        if (!Files.exists(mapIdsFile)) {
+            Bukkit.createMap(mainWorld);
+            if (!Files.exists(mapIdsFile)) {
+                DrMap.getInstance().getLogger().warning("Could not bump map ID to: " + highestId + ". Could not find idcounts.dat: " + mapIdsFile);
+                return false;
+            }
+        }
+
+        // Step 1: Read the Gzip'd NBT data
+        CompoundBinaryTag nbt = BinaryTagIO.reader().read(mapIdsFile, BinaryTagIO.Compression.GZIP);
+
+        // Step 2: Verify required fields
+        CompoundBinaryTag nbtData = nbt.getCompound("data");
+        if (nbtData == null) {
+            DrMap.getInstance().getLogger().severe("Missing data(compound) field in: " + nbt + " for: " + mapIdsFile);
+            return false;
+        }
+        if (!(nbtData.get("map") instanceof IntBinaryTag)) {
+            DrMap.getInstance().getLogger().severe("Missing map(int) field in: data." + nbtData + " for: " + mapIdsFile);
+            return false;
+        }
+
+        int mapId = nbtData.getInt("map");
+        if (mapId >= highestId)
+            return true;
+
+        // Step 3: Bump map ID
+        nbtData.putInt("map", highestId);
+        // write to tmp file to prevent corrupting the servers id counter if we fail
+        Path idCountsTmp = mapIdsFile.resolveSibling(mapIdsFile.getFileName() + ".drmap.tmp");
+        BinaryTagIO.writer().write(nbt, idCountsTmp, BinaryTagIO.Compression.GZIP);
+        Files.move(idCountsTmp, mapIdsFile, StandardCopyOption.REPLACE_EXISTING);
+        DrMap.getInstance().getLogger().info("Updated " + mapIdsFile.getFileName() + " from " + mapId + " to " + highestId + ".");
+        return true;
+    }
+
 }


### PR DESCRIPTION
The plugin broke in 26.1 due to world directory structure and caching changes.  
Bumping the map ID by the data file no longer works, as the value is cached in memory now. It will be overwritten the moment data is saved.

Changes:
1. Use reflection to bump map ids for 26+ versions.
As the game now ships unobfuscated, the member names will only change if Mojang actually changes them.
2. Use net.kyori.adventure-nbt as the nbt library
3. Bump bstats version
4. Enable the minimizeJar shade option to expel unused class files.